### PR TITLE
Fix SluggableScopeHelpers::scopeWhereSlug() signature

### DIFF
--- a/src/ModelTraits/SpatieTranslatable/SluggableScopeHelpers.php
+++ b/src/ModelTraits/SpatieTranslatable/SluggableScopeHelpers.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\ModelTraits\SpatieTranslatable;
 
+use Illuminate\Database\Eloquent\Builder;
 use Cviebrock\EloquentSluggable\SluggableScopeHelpers as OriginalSluggableScopeHelpers;
 
 trait SluggableScopeHelpers
@@ -15,7 +16,7 @@ trait SluggableScopeHelpers
      * @param string $slug
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeWhereSlug($scope, $slug)
+    public function scopeWhereSlug(Builder $scope, $slug)
     {
         return $scope->where($this->getSlugKeyName().'->'.$this->getLocale(), $slug);
     }


### PR DESCRIPTION
Hi,

There is an issue with the signature of method `scopeWhereSlug` of the trait `Backpack\CRUD\ModelTraits\SpatieTranslatable\SluggableScopeHelpers`.

The overriden method signature is :
```php
public function scopeWhereSlug($scope, $slug)
```

.. but the original trait has this signature :

```php
public function scopeWhereSlug(Builder $scope, $slug)
```

This can be reproduced by extending the model `Backpack\PageManager\app\Models\Page` and implementing the multilanguage slug traits provided by the Backpack CRUD package:

```php
namespace App\Models;

use Backpack\PageManager\app\Models\Page as BackpackPage;
use Backpack\CRUD\ModelTraits\SpatieTranslatable\HasTranslations;
use Backpack\CRUD\ModelTraits\SpatieTranslatable\Sluggable;
use Backpack\CRUD\ModelTraits\SpatieTranslatable\SluggableScopeHelpers;

class Page extends BackpackPage
{
    use Sluggable;
    use SluggableScopeHelpers;
    use HasTranslations;

    protected $translatable = ['slug', 'name', 'title', 'content'];
}

```

This will produces the error :
> Declaration of Backpack\CRUD\ModelTraits\SpatieTranslatable\SluggableScopeHelpers::scopeWhereSlug($scope, $slug) should be compatible with Backpack\PageManager\app\Models\Page::scopeWhereSlug(Illuminate\Database\Eloquent\Builder $scope, $slug)